### PR TITLE
Update EVE_MCU_FT9XX.c

### DIFF
--- a/lib/eve/ports/eve_arch_ft9xx/EVE_MCU_FT9XX.c
+++ b/lib/eve/ports/eve_arch_ft9xx/EVE_MCU_FT9XX.c
@@ -62,6 +62,7 @@
 
 #include "../include/MCU.h"
 #include "EVE_config.h"
+#include "FT8xx.h"
 
 // SPI Master pins
 #if defined(__FT900__)


### PR DESCRIPTION
adding in #include "FT8xx.h" as EVEx_Enable values are defined in there